### PR TITLE
Fix zero read on DMA peripheral access

### DIFF
--- a/core/rtl/verilog/omsp_mem_backbone.v
+++ b/core/rtl/verilog/omsp_mem_backbone.v
@@ -28,7 +28,7 @@
 //----------------------------------------------------------------------------
 //
 // *File Name: omsp_mem_backbone.v
-// 
+//
 // *Module Description:
 //                       Memory interface backbone (decoder + arbiter)
 //
@@ -241,7 +241,7 @@ assign             ext_dmem_sel  = (ext_mem_addr[15:1]>=(`DMEM_BASE>>1)) &
 assign             ext_dmem_en   = ext_mem_en &  ext_dmem_sel & ~eu_dmem_en;
 wire        [15:0] ext_dmem_addr = {1'b0, ext_mem_addr[15:1]}-(`DMEM_BASE>>1);
 
-   
+
 // RAM Interface
 // NOTE: allow DMA ext access on violation
 wire               eu_dmem_en_ok =  eu_dmem_en & ~sm_violation;
@@ -265,7 +265,7 @@ wire        [15:0] eu_pmem_addr  = eu_mab-(PMEM_OFFSET>>1);
 
 // Front-end access
 // NOTE: do not mask __front-end__ program memory accesses on sm_violation,
-// to allow frontendto fetch valid ISR instruction from since pmem 
+// to allow frontendto fetch valid ISR instruction from since pmem
 // TODO prevent jumping to non SM-entry point ISR (?)
 wire               fe_pmem_sel   = (fe_mab>=(PMEM_OFFSET>>1));
 wire               fe_pmem_en    = fe_mb_en & fe_pmem_sel;
@@ -278,7 +278,7 @@ assign             ext_pmem_en  = ext_mem_en & ext_pmem_sel & ~eu_pmem_en & ~fe_
 
 wire        [15:0] ext_pmem_addr = {1'b0, ext_mem_addr[15:1]}-(PMEM_OFFSET>>1);
 
-   
+
 // Program-Memory Interface (Execution unit has priority over the Front-end)
 wire               pmem_cen      = ~(fe_pmem_en | eu_pmem_en | ext_pmem_en);
 wire         [1:0] pmem_wen      =  ext_pmem_en ? ~ext_mem_wr : (eu_pmem_en ? ~eu_mb_wr : 2'b11); //(sergio) corretto
@@ -338,7 +338,7 @@ omsp_clock_gate clock_gate_bckup (.gclk(mclk_bckup),
 `else
 wire mclk_bckup = mclk;
 `endif
-   
+
 reg  [15:0] pmem_dout_bckup;
 always @(posedge mclk_bckup or posedge puc_rst)
   if (puc_rst)           pmem_dout_bckup     <=  16'h0000;
@@ -354,7 +354,7 @@ always @(posedge mclk or posedge puc_rst)
   if (puc_rst)              pmem_dout_bckup_sel <=  1'b0;
   else if (fe_pmem_save)    pmem_dout_bckup_sel <=  1'b1;
   else if (fe_pmem_restore) pmem_dout_bckup_sel <=  1'b0;
-    
+
 assign fe_mdb_in = pmem_dout_bckup_sel ? pmem_dout_bckup : pmem_dout;
 
 
@@ -365,7 +365,7 @@ assign fe_mdb_in = pmem_dout_bckup_sel ? pmem_dout_bckup : pmem_dout;
 reg [1:0] eu_mdb_in_sel;
 always @(posedge mclk or posedge puc_rst)
   if (puc_rst)  eu_mdb_in_sel <= 2'b00;
-  else          eu_mdb_in_sel <= {eu_pmem_en, per_en};
+  else          eu_mdb_in_sel <= {eu_pmem_en, eu_per_en};
 
 // Mux
 wire [15:0]     raw_eu_mdb_in = eu_mdb_in_sel[1] ? pmem_dout    :
@@ -390,12 +390,12 @@ reg   [1:0] ext_mem_din_sel;
 always @(posedge mclk or posedge puc_rst)
   if (puc_rst)  ext_mem_din_sel <= 2'b00;
   else          ext_mem_din_sel <= {ext_pmem_en, ext_per_en};
-     
+
 // Mux
 assign      ext_mem_din  = ext_mem_din_sel[1] ? pmem_dout    :
                            ext_mem_din_sel[0] ? per_dout_val : dmem_dout;
 
-   
+
 endmodule // omsp_mem_backbone
 `ifdef OMSP_NO_INCLUDE
 `else

--- a/core/sim/rtl_sim/run/run_all_sancus
+++ b/core/sim/rtl_sim/run/run_all_sancus
@@ -31,6 +31,7 @@ __SANCUS_SIM=1
 export __SANCUS_SIM
 
 stdbuf -oL ../bin/msp430sim sancus/sm_dma_peripheral                  | tee ./log/sancus-sm_dma_peripheral.log
+stdbuf -oL ../bin/msp430sim sancus/sm_dma_zero                  | tee ./log/sancus-sm_dma_zero.log
 
 # Report regression results
 ../bin/parse_results

--- a/core/sim/rtl_sim/src/sancus/sm_dma_zero.s43
+++ b/core/sim/rtl_sim/src/sancus/sm_dma_zero.s43
@@ -1,0 +1,68 @@
+.include "pmem_defs.asm"
+.include "sancus_macros.asm"
+
+.set foo_secret_start, DMEM_262
+.set foo_secret_end, DMEM_268
+
+.set dma_addr, (0x0070)
+.set dma_cnt, (0x0072)
+.set dma_trace, (0x0074)
+
+.global main
+main:
+    clr r15
+
+    disable_wdt
+    eint
+    sancus_enable #1234, #foo_text_start, #foo_text_end, #foo_secret_start, #foo_secret_end
+
+    mov #0x50, &dma_addr
+    mov #0x01, r10
+    br #foo_text_start
+
+    /* ----------------------         SANCUS MODULE      --------------- */
+
+foo_text_start:
+    cmp #0x00, r10
+    jz 1f
+    mov #0x42, &foo_secret_start
+    mov &foo_secret_start, r8
+    jmp 2f
+1:  mov &foo_secret_start, r9
+2:  nop
+foo_text_end:
+    nop
+
+    /* ----------------------        END     --------------- */
+
+end_of_test:
+    nop
+    nop
+    nop
+    nop
+    cmp #0x00, r10
+    jz 3f
+    mov #0x00, r10
+    mov #0x02, &dma_cnt
+    br #foo_text_start
+3:  mov #0x2000, r15
+fail_test:
+    br #0xffff
+
+.section .vectors, "a"
+.word end_of_test  ; Interrupt  0 (lowest priority)    <unused>
+.word end_of_test  ; Interrupt  1                      <unused>
+.word end_of_test  ; Interrupt  2                      <unused>
+.word end_of_test  ; Interrupt  3                      <unused>
+.word end_of_test  ; Interrupt  4                      <unused>
+.word end_of_test  ; Interrupt  5                      <unused>
+.word end_of_test  ; Interrupt  6                      <unused>
+.word end_of_test  ; Interrupt  7                      <unused>
+.word end_of_test  ; Interrupt  8                      <unused>
+.word end_of_test  ; Interrupt  9                      TEST IRQ
+.word end_of_test  ; Interrupt 10                      Watchdog timer
+.word end_of_test  ; Interrupt 11                      <unused>
+.word end_of_test  ; Interrupt 12                      <unused>
+.word end_of_test  ; Interrupt 13                      SM_IRQ
+.word end_of_test  ; Interrupt 14                      NMI
+.word main         ; Interrupt 15 (highest priority)   RESET

--- a/core/sim/rtl_sim/src/sancus/sm_dma_zero.v
+++ b/core/sim/rtl_sim/src/sancus/sm_dma_zero.v
@@ -1,0 +1,25 @@
+initial
+   begin
+      $display("===============================================");
+      $display("                 START SIMULATION             |");
+      $display("===============================================");
+      #10;
+
+      repeat(5) @(posedge mclk);
+      stimulus_done = 0;
+
+      /* ----------------------  INITIALIZATION --------------- */
+
+      $display("waiting for foo entry..");
+      while(~sm_0_executing) @(posedge mclk);
+
+      /* ----------------------  END OF TEST --------------- */
+      @(r15==16'h2000);
+
+      if(r8 !== 16'h42)
+         tb_error("====== r8 does not mach expected value ======");
+      if(r9 !== 16'h42)
+         tb_error("====== r9 does not mach expected value ======");
+
+      stimulus_done = 1;
+   end


### PR DESCRIPTION
This pull request fixes a bug which caused some memory reads by the execution unit to return 0 if a DMA device accesses a memory-mapped I/O address in the same clock cycle. 

The execution unit code now checks the `eu_per_en` signal instead of the `per_en` to decide whether it needs to access the peripheral data output bus. (The latter signal is high when a DMA device accesses a MMIO address, while the former is only high if the execution unit initiates the access.)

The pull request also contains a test for this fix.